### PR TITLE
Map cashier actions to 'batal' and 'selesai' booking statuses

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -108,11 +108,18 @@ class Booking extends CI_Controller
             redirect('dashboard');
         }
         $status = $this->input->post('status');
-        $allowed = ['confirmed','cancelled','completed'];
-        if (!in_array($status, $allowed)) {
+        // Izinkan baik istilah bahasa Inggris maupun Indonesia
+        $allowed = [
+            'confirmed' => 'confirmed',
+            'cancelled' => 'batal',
+            'completed' => 'selesai',
+            'batal'     => 'batal',
+            'selesai'   => 'selesai'
+        ];
+        if (!array_key_exists($status, $allowed)) {
             show_error('Status tidak valid', 400);
         }
-        $this->Booking_model->update($id, ['status_booking' => $status]);
+        $this->Booking_model->update($id, ['status_booking' => $allowed[$status]]);
         $this->session->set_flashdata('success', 'Status booking diperbarui.');
         redirect('booking');
     }

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -38,17 +38,17 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Confirm</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php elseif ($b->status_booking === 'confirmed'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="completed">
-                                <button type="submit" class="btn btn-sm btn-success">Complete</button>
+                                <input type="hidden" name="status" value="selesai">
+                                <button type="submit" class="btn btn-sm btn-success">Selesai</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
                     </td>


### PR DESCRIPTION
## Summary
- Map cancel and complete actions to Indonesian booking statuses
- Update cashier view buttons to send and display `batal` and `selesai`

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83cdbf0c48320a3dd4e7ff923a0ad