### PR TITLE
Map cashier actions to booking statuses and reopen cancelled slots

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -108,11 +108,18 @@ class Booking extends CI_Controller
             redirect('dashboard');
         }
         $status = $this->input->post('status');
-        $allowed = ['confirmed','cancelled','completed'];
-        if (!in_array($status, $allowed)) {
+        // Izinkan baik istilah bahasa Inggris maupun Indonesia
+        $allowed = [
+            'confirmed' => 'confirmed',
+            'cancelled' => 'batal',
+            'completed' => 'selesai',
+            'batal'     => 'batal',
+            'selesai'   => 'selesai'
+        ];
+        if (!array_key_exists($status, $allowed)) {
             show_error('Status tidak valid', 400);
         }
-        $this->Booking_model->update($id, ['status_booking' => $status]);
+        $this->Booking_model->update($id, ['status_booking' => $allowed[$status]]);
         $this->session->set_flashdata('success', 'Status booking diperbarui.');
         redirect('booking');
     }

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -10,7 +10,9 @@ class Booking_model extends CI_Model
 
     public function get_by_date($date)
     {
-        return $this->db->get_where($this->table, ['tanggal_booking' => $date])->result();
+        $this->db->where('tanggal_booking', $date);
+        $this->db->where('status_booking !=', 'batal');
+        return $this->db->get($this->table)->result();
     }
 
     public function insert($data)
@@ -28,12 +30,16 @@ class Booking_model extends CI_Model
          * Cek ketersediaan jadwal. Bentrok jika rentang waktu overlap:
          * tidak bentrok jika (jam_selesai <= start) OR (jam_mulai >= end)
          * maka kondisi bentrok adalah negasi dari kondisi tersebut.
+         * Abaikan booking yang sudah dibatalkan.
          */
         $this->db->where('id_court', $id_court);
         $this->db->where('tanggal_booking', $date);
-        $this->db->where("NOT (jam_selesai <= '{$start}' OR jam_mulai >= '{$end}')", NULL, FALSE);
-        $conflict = $this->db->get($this->table)->num_rows();
-        return $conflict == 0;
+        $this->db->where('status_booking !=', 'batal');
+        $this->db->group_start();
+        $this->db->where('jam_selesai >', $start);
+        $this->db->where('jam_mulai <', $end);
+        $this->db->group_end();
+        return $this->db->get($this->table)->num_rows() === 0;
     }
 
     /**

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -38,17 +38,17 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Confirm</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php elseif ($b->status_booking === 'confirmed'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="completed">
-                                <button type="submit" class="btn btn-sm btn-success">Complete</button>
+                                <input type="hidden" name="status" value="selesai">
+                                <button type="submit" class="btn btn-sm btn-success">Selesai</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
                     </td>


### PR DESCRIPTION
## Summary
- Map cancel and complete actions to Indonesian booking statuses
- Ignore cancelled bookings when listing or checking availability so slots can be rebooked

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/index.php`
- `php -l application/models/Booking_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83cdbf0c48320a3dd4e7ff923a0ad