### PR TITLE
Auto-fill booking confirmation note and add cancelled bookings menu

### DIFF
--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -10,12 +10,23 @@ class Booking_model extends CI_Model
 
     public function get_by_date($date)
     {
-        return $this->db->get_where($this->table, ['tanggal_booking' => $date])->result();
+        $this->db->where('tanggal_booking', $date);
+        $this->db->where('status_booking !=', 'batal');
+        return $this->db->get($this->table)->result();
     }
 
     public function insert($data)
     {
         return $this->db->insert($this->table, $data);
+    }
+
+    /**
+     * Ambil daftar booking yang dibatalkan.
+     */
+    public function get_cancelled()
+    {
+        $this->db->where('status_booking', 'batal');
+        return $this->db->order_by('tanggal_booking', 'desc')->get($this->table)->result();
     }
 
     /**
@@ -28,12 +39,16 @@ class Booking_model extends CI_Model
          * Cek ketersediaan jadwal. Bentrok jika rentang waktu overlap:
          * tidak bentrok jika (jam_selesai <= start) OR (jam_mulai >= end)
          * maka kondisi bentrok adalah negasi dari kondisi tersebut.
+         * Abaikan booking yang sudah dibatalkan.
          */
         $this->db->where('id_court', $id_court);
         $this->db->where('tanggal_booking', $date);
-        $this->db->where("NOT (jam_selesai <= '{$start}' OR jam_mulai >= '{$end}')", NULL, FALSE);
-        $conflict = $this->db->get($this->table)->num_rows();
-        return $conflict == 0;
+        $this->db->where('status_booking !=', 'batal');
+        $this->db->group_start();
+        $this->db->where('jam_selesai >', $start);
+        $this->db->where('jam_mulai <', $end);
+        $this->db->group_end();
+        return $this->db->get($this->table)->num_rows() === 0;
     }
 
     /**

--- a/application/views/booking/cancelled.php
+++ b/application/views/booking/cancelled.php
@@ -1,0 +1,31 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Booking Batal</h2>
+<?php if (!empty($bookings)): ?>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Lapangan</th>
+                <th>Pelanggan</th>
+                <th>Jam Mulai</th>
+                <th>Jam Selesai</th>
+                <th>Keterangan</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($bookings as $b): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($b->tanggal_booking); ?></td>
+                <td><?php echo htmlspecialchars($b->id_court); ?></td>
+                <td><?php echo htmlspecialchars($b->id_user); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php else: ?>
+    <p>Tidak ada booking batal.</p>
+<?php endif; ?>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -17,6 +17,7 @@
                 <th>Jam Mulai</th>
                 <th>Jam Selesai</th>
                 <th>Status</th>
+                <th>Keterangan</th>
                 <?php if ($role === 'kasir'): ?>
                     <th>Aksi</th>
                 <?php endif; ?>
@@ -30,6 +31,7 @@
                 <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
                     <td>
                         <?php if ($b->status_booking === 'pending'): ?>
@@ -38,17 +40,15 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Confirm</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php elseif ($b->status_booking === 'confirmed'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="completed">
-                                <button type="submit" class="btn btn-sm btn-success">Complete</button>
-                            </form>
-                            <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" name="status" value="selesai" class="btn btn-sm btn-success">Selesai</button>
+                                <button type="submit" name="status" value="batal" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
                     </td>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -17,7 +17,13 @@
         <ul class="navbar-nav mr-auto">
             <?php if ($this->session->userdata('logged_in')): ?>
                 <?php $role = $this->session->userdata('role'); ?>
-                <li class="nav-item"><a class="nav-link" href="<?php echo site_url('booking'); ?>">Booking</a></li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="bookingDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Booking</a>
+                    <div class="dropdown-menu" aria-labelledby="bookingDropdown">
+                        <a class="dropdown-item" href="<?php echo site_url('booking'); ?>">Jadwal Booking Lapangan</a>
+                        <a class="dropdown-item" href="<?php echo site_url('booking/cancelled'); ?>">Booking Batal</a>
+                    </div>
+                </li>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('pos'); ?>">POS</a></li>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Populate booking notes with "pembayaran sudah di konfirmasi" when a cashier confirms a booking
- Avoid duplicate note fields when completing or canceling confirmed bookings
- Add Booking dropdown menu linking to schedule and cancelled bookings list
- Expose controller action and view to review cancelled bookings

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/models/Booking_model.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/booking/cancelled.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83cdbf0c48320a3dd4e7ff923a0ad