### PR TITLE
Add customer booking overview and user profile management

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -87,12 +87,25 @@ class Booking extends CI_Controller
                 'status_booking'   => 'pending',
                 'status_pembayaran'=> 'belum_bayar'
             ];
-            $this->Booking_model->insert($data);
-            $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-            redirect('booking');
-            return;
-        }
+        $this->Booking_model->insert($data);
+        $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
+        redirect('booking');
+        return;
+    }
         $this->create();
+    }
+
+    /**
+     * Tampilkan daftar booking milik user yang sedang login.
+     */
+    public function my()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $user_id = $this->session->userdata('id');
+        $data['bookings'] = $this->Booking_model->get_by_user($user_id);
+        $this->load->view('booking/my', $data);
     }
 
     /**
@@ -107,13 +120,53 @@ class Booking extends CI_Controller
         if ($role !== 'kasir') {
             redirect('dashboard');
         }
-        $status = $this->input->post('status');
-        $allowed = ['confirmed','cancelled','completed'];
-        if (!in_array($status, $allowed)) {
+        $status     = $this->input->post('status');
+        $keterangan = $this->input->post('keterangan');
+        // Izinkan baik istilah bahasa Inggris maupun Indonesia
+        $allowed = [
+            'confirmed' => 'confirmed',
+            'cancelled' => 'batal',
+            'completed' => 'selesai',
+            'batal'     => 'batal',
+            'selesai'   => 'selesai'
+        ];
+        if (!array_key_exists($status, $allowed)) {
             show_error('Status tidak valid', 400);
         }
-        $this->Booking_model->update($id, ['status_booking' => $status]);
+        $normalized = $allowed[$status];
+        $data       = ['status_booking' => $normalized];
+        if ($normalized === 'confirmed') {
+            $data['keterangan'] = 'pembayaran sudah di konfirmasi';
+        } elseif ($keterangan !== null) {
+            $data['keterangan'] = $keterangan;
+        }
+        $this->Booking_model->update($id, $data);
         $this->session->set_flashdata('success', 'Status booking diperbarui.');
         redirect('booking');
+    }
+
+    /**
+     * Tampilkan daftar booking yang dibatalkan.
+     */
+    public function cancelled()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+
+        $role = $this->session->userdata('role');
+        if (!in_array($role, ['kasir', 'admin_keuangan', 'owner'])) {
+            show_error('Forbidden', 403);
+        }
+
+        $date = $this->input->get('date');
+        if (!$date) {
+            $date = $this->input->get('tanggal');
+        }
+
+        $data['date'] = $date;
+        $data['bookings'] = !empty($date) ? $this->Booking_model->get_cancelled($date) : [];
+
+        $this->load->view('booking/cancelled', $data);
     }
 }

--- a/application/controllers/Finance.php
+++ b/application/controllers/Finance.php
@@ -2,7 +2,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
- * Controller laporan keuangan untuk admin_keuangan dan owner.
+ * Controller laporan keuangan untuk kasir, admin_keuangan dan owner.
  */
 class Finance extends CI_Controller
 {
@@ -20,7 +20,7 @@ class Finance extends CI_Controller
             redirect('auth/login');
         }
         $role = $this->session->userdata('role');
-        if (!in_array($role, ['admin_keuangan','owner'])) {
+        if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
             redirect('dashboard');
         }
     }

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -1,0 +1,100 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk manajemen pengguna dan profil.
+ */
+class Users extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('User_model');
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+    }
+
+    /**
+     * Daftar semua pengguna (owner saja).
+     */
+    public function index()
+    {
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $data['users'] = $this->User_model->get_all();
+        $this->load->view('users/index', $data);
+    }
+
+    /**
+     * Edit profil pengguna. Jika $id null, edit profil sendiri.
+     * Owner dapat mengedit semua user termasuk role.
+     */
+    public function profile($id = NULL)
+    {
+        $current_id = $this->session->userdata('id');
+        $current_role = $this->session->userdata('role');
+
+        if ($id === NULL) {
+            $id = $current_id;
+        } elseif ($current_role !== 'owner' && (int)$id !== (int)$current_id) {
+            show_error('Forbidden', 403);
+        }
+
+        $user = $this->User_model->get_by_id($id);
+        if (!$user) {
+            show_404();
+        }
+
+        if ($this->input->method() === 'post') {
+            $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
+            $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+            if ($this->input->post('password')) {
+                $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
+            }
+            if ($current_role === 'owner') {
+                $this->form_validation->set_rules('role', 'Role', 'required|in_list[pelanggan,kasir,admin_keuangan,owner]');
+            }
+            if ($this->form_validation->run() === TRUE) {
+                $update = [
+                    'nama_lengkap' => $this->input->post('nama_lengkap', TRUE),
+                    'email'        => $this->input->post('email', TRUE),
+                    'no_telepon'   => $this->input->post('no_telepon', TRUE)
+                ];
+                if ($this->input->post('password')) {
+                    $update['password'] = password_hash($this->input->post('password'), PASSWORD_DEFAULT);
+                }
+                if ($current_role === 'owner') {
+                    $update['role'] = $this->input->post('role', TRUE);
+                }
+                $this->User_model->update($id, $update);
+
+                // perbarui session jika mengubah diri sendiri
+                if ((int)$id === (int)$current_id) {
+                    $session_update = [
+                        'nama_lengkap' => $update['nama_lengkap'],
+                        'email'        => $update['email']
+                    ];
+                    if ($current_role === 'owner' && isset($update['role'])) {
+                        $session_update['role'] = $update['role'];
+                    }
+                    $this->session->set_userdata($session_update);
+                }
+
+                $this->session->set_flashdata('success', 'Profil berhasil diperbarui.');
+                if ($current_role === 'owner' && (int)$id !== (int)$current_id) {
+                    redirect('users');
+                } else {
+                    redirect('users/profile');
+                }
+                return;
+            }
+        }
+
+        $data['user'] = $user;
+        $this->load->view('users/profile', $data);
+    }
+}

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -10,12 +10,42 @@ class Booking_model extends CI_Model
 
     public function get_by_date($date)
     {
-        return $this->db->get_where($this->table, ['tanggal_booking' => $date])->result();
+        $this->db->where('tanggal_booking', $date);
+        $this->db->where('status_booking !=', 'batal');
+        return $this->db->get($this->table)->result();
     }
 
     public function insert($data)
     {
         return $this->db->insert($this->table, $data);
+    }
+
+    /**
+     * Ambil semua booking milik pengguna tertentu.
+     */
+    public function get_by_user($id_user)
+    {
+        return $this->db->select('bookings.*, courts.nama_lapangan')
+                        ->from($this->table)
+                        ->join('courts', 'courts.id = bookings.id_court')
+                        ->where('bookings.id_user', $id_user)
+                        ->order_by('tanggal_booking', 'desc')
+                        ->get()
+                        ->result();
+    }
+
+    /**
+     * Ambil daftar booking yang dibatalkan.
+     */
+    public function get_cancelled($date = null)
+    {
+        $this->db->where('status_booking', 'batal');
+        if (!empty($date)) {
+            $this->db->where('tanggal_booking', $date);
+        }
+        return $this->db->order_by('tanggal_booking', 'desc')
+                        ->get($this->table)
+                        ->result();
     }
 
     /**
@@ -28,12 +58,16 @@ class Booking_model extends CI_Model
          * Cek ketersediaan jadwal. Bentrok jika rentang waktu overlap:
          * tidak bentrok jika (jam_selesai <= start) OR (jam_mulai >= end)
          * maka kondisi bentrok adalah negasi dari kondisi tersebut.
+         * Abaikan booking yang sudah dibatalkan.
          */
         $this->db->where('id_court', $id_court);
         $this->db->where('tanggal_booking', $date);
-        $this->db->where("NOT (jam_selesai <= '{$start}' OR jam_mulai >= '{$end}')", NULL, FALSE);
-        $conflict = $this->db->get($this->table)->num_rows();
-        return $conflict == 0;
+        $this->db->where('status_booking !=', 'batal');
+        $this->db->group_start();
+        $this->db->where('jam_selesai >', $start);
+        $this->db->where('jam_mulai <', $end);
+        $this->db->group_end();
+        return $this->db->get($this->table)->num_rows() === 0;
     }
 
     /**

--- a/application/views/booking/cancelled.php
+++ b/application/views/booking/cancelled.php
@@ -1,0 +1,38 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Booking Batal</h2>
+
+<form method="get" action="<?php echo site_url('booking/cancelled'); ?>" class="form-inline mb-3">
+    <label for="date" class="mr-2">Tanggal:</label>
+    <input type="date" id="date" name="date" class="form-control mr-2" value="<?php echo htmlspecialchars($date); ?>">
+    <button type="submit" class="btn btn-primary">Lihat</button>
+</form>
+
+<?php if (!empty($bookings)): ?>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Lapangan</th>
+                <th>Pelanggan</th>
+                <th>Jam Mulai</th>
+                <th>Jam Selesai</th>
+                <th>Keterangan</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($bookings as $b): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($b->id_court); ?></td>
+                <td><?php echo htmlspecialchars($b->id_user); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php elseif ($date): ?>
+    <p>Tidak ada booking batal pada tanggal ini.</p>
+<?php else: ?>
+    <p>Silakan pilih tanggal.</p>
+<?php endif; ?>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -17,6 +17,7 @@
                 <th>Jam Mulai</th>
                 <th>Jam Selesai</th>
                 <th>Status</th>
+                <th>Keterangan</th>
                 <?php if ($role === 'kasir'): ?>
                     <th>Aksi</th>
                 <?php endif; ?>
@@ -30,6 +31,7 @@
                 <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
                     <td>
                         <?php if ($b->status_booking === 'pending'): ?>
@@ -38,17 +40,15 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Confirm</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php elseif ($b->status_booking === 'confirmed'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="completed">
-                                <button type="submit" class="btn btn-sm btn-success">Complete</button>
-                            </form>
-                            <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" name="status" value="selesai" class="btn btn-sm btn-success">Selesai</button>
+                                <button type="submit" name="status" value="batal" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
                     </td>

--- a/application/views/booking/my.php
+++ b/application/views/booking/my.php
@@ -1,0 +1,33 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Booking Saya</h2>
+<a href="<?php echo site_url('booking/create'); ?>" class="btn btn-success mb-3">Booking Baru</a>
+<?php if (empty($bookings)): ?>
+    <p>Belum ada booking.</p>
+<?php else: ?>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Tanggal</th>
+            <th>Lapangan</th>
+            <th>Jam Mulai</th>
+            <th>Jam Selesai</th>
+            <th>Status</th>
+            <th>Keterangan</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($bookings as $b): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($b->tanggal_booking); ?></td>
+            <td><?php echo htmlspecialchars($b->nama_lapangan); ?></td>
+            <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
+            <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
+            <td><?php echo htmlspecialchars(ucfirst($b->status_booking)); ?></td>
+            <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif; ?>
+<?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -17,15 +17,27 @@
         <ul class="navbar-nav mr-auto">
             <?php if ($this->session->userdata('logged_in')): ?>
                 <?php $role = $this->session->userdata('role'); ?>
-                <li class="nav-item"><a class="nav-link" href="<?php echo site_url('booking'); ?>">Booking</a></li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="bookingDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Booking</a>
+                    <div class="dropdown-menu" aria-labelledby="bookingDropdown">
+                        <?php if ($role === 'pelanggan'): ?>
+                            <a class="dropdown-item" href="<?php echo site_url('booking/my'); ?>">Booking Saya</a>
+                        <?php endif; ?>
+                        <a class="dropdown-item" href="<?php echo site_url('booking'); ?>">Jadwal Booking Lapangan</a>
+                        <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
+                            <a class="dropdown-item" href="<?php echo site_url('booking/cancelled'); ?>">Booking Batal</a>
+                        <?php endif; ?>
+                    </div>
+                </li>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('pos'); ?>">POS</a></li>
                 <?php endif; ?>
                 <?php if ($role === 'owner'): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('courts'); ?>">Lapangan</a></li>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('reports'); ?>">Laporan</a></li>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users'); ?>">Users</a></li>
                 <?php endif; ?>
-                <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
+                <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('finance'); ?>">Keuangan</a></li>
                 <?php endif; ?>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
@@ -36,6 +48,7 @@
         <ul class="navbar-nav">
             <?php if ($this->session->userdata('logged_in')): ?>
                 <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
+                <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users/profile'); ?>">Profil</a></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/logout'); ?>">Logout</a></li>
             <?php else: ?>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/login'); ?>">Login</a></li>

--- a/application/views/users/index.php
+++ b/application/views/users/index.php
@@ -1,0 +1,23 @@
+<?php $this->load->view('templates/header'); ?>
+<h1>Daftar Pengguna</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Nama</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($users as $u): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($u->nama_lengkap); ?></td>
+            <td><?php echo htmlspecialchars($u->email); ?></td>
+            <td><?php echo htmlspecialchars($u->role); ?></td>
+            <td><a href="<?php echo site_url('users/profile/'.$u->id); ?>" class="btn btn-sm btn-primary">Edit</a></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/users/profile.php
+++ b/application/views/users/profile.php
@@ -1,0 +1,36 @@
+<?php $this->load->view('templates/header'); ?>
+<h1>Edit Profil</h1>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<?php echo form_open(); ?>
+<div class="form-group">
+    <label>Nama Lengkap</label>
+    <input type="text" name="nama_lengkap" class="form-control" value="<?php echo set_value('nama_lengkap', $user->nama_lengkap); ?>">
+</div>
+<div class="form-group">
+    <label>Email</label>
+    <input type="email" name="email" class="form-control" value="<?php echo set_value('email', $user->email); ?>">
+</div>
+<div class="form-group">
+    <label>No Telepon</label>
+    <input type="text" name="no_telepon" class="form-control" value="<?php echo set_value('no_telepon', $user->no_telepon); ?>">
+</div>
+<div class="form-group">
+    <label>Password (kosongkan jika tidak ganti)</label>
+    <input type="password" name="password" class="form-control">
+</div>
+<?php if ($this->session->userdata('role') === 'owner'): ?>
+<div class="form-group">
+    <label>Role</label>
+    <select name="role" class="form-control">
+        <?php $roles = ['pelanggan' => 'Pelanggan', 'kasir' => 'Kasir', 'admin_keuangan' => 'Admin Keuangan', 'owner' => 'Owner']; ?>
+        <?php foreach ($roles as $key => $label): ?>
+            <option value="<?php echo $key; ?>" <?php echo set_select('role', $key, $user->role === $key); ?>><?php echo $label; ?></option>
+        <?php endforeach; ?>
+    </select>
+</div>
+<?php endif; ?>
+<button type="submit" class="btn btn-primary">Simpan</button>
+<?php echo form_close(); ?>
+<?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
## Summary
- add `get_by_user` model helper and controller action to list a customer's own bookings
- expose "Booking Saya" link in the navbar for customer role and add dedicated view
- restrict "Booking Batal" menu and page access to cashier, finance admin, and owner roles
- allow cashier role to open the finance reports menu
- introduce profile editing pages so users can update their details while only owners may change roles

## Testing
- `php -l application/models/Booking_model.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/booking/my.php`
- `php -l application/views/booking/cancelled.php`
- `php -l application/views/booking/index.php`
- `php -l application/controllers/Finance.php`
- `php -l application/views/finance/index.php`
- `php -l application/controllers/Users.php`
- `php -l application/views/users/index.php`
- `php -l application/views/users/profile.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83cdbf0c48320a3dd4e7ff923a0ad