### PR TITLE
Add customer booking overview, user profile management, and detailed finance report

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -87,12 +87,25 @@ class Booking extends CI_Controller
                 'status_booking'   => 'pending',
                 'status_pembayaran'=> 'belum_bayar'
             ];
-            $this->Booking_model->insert($data);
-            $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-            redirect('booking');
-            return;
-        }
+        $this->Booking_model->insert($data);
+        $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
+        redirect('booking');
+        return;
+    }
         $this->create();
+    }
+
+    /**
+     * Tampilkan daftar booking milik user yang sedang login.
+     */
+    public function my()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $user_id = $this->session->userdata('id');
+        $data['bookings'] = $this->Booking_model->get_by_user($user_id);
+        $this->load->view('booking/my', $data);
     }
 
     /**
@@ -107,13 +120,53 @@ class Booking extends CI_Controller
         if ($role !== 'kasir') {
             redirect('dashboard');
         }
-        $status = $this->input->post('status');
-        $allowed = ['confirmed','cancelled','completed'];
-        if (!in_array($status, $allowed)) {
+        $status     = $this->input->post('status');
+        $keterangan = $this->input->post('keterangan');
+        // Izinkan baik istilah bahasa Inggris maupun Indonesia
+        $allowed = [
+            'confirmed' => 'confirmed',
+            'cancelled' => 'batal',
+            'completed' => 'selesai',
+            'batal'     => 'batal',
+            'selesai'   => 'selesai'
+        ];
+        if (!array_key_exists($status, $allowed)) {
             show_error('Status tidak valid', 400);
         }
-        $this->Booking_model->update($id, ['status_booking' => $status]);
+        $normalized = $allowed[$status];
+        $data       = ['status_booking' => $normalized];
+        if ($normalized === 'confirmed') {
+            $data['keterangan'] = 'pembayaran sudah di konfirmasi';
+        } elseif ($keterangan !== null) {
+            $data['keterangan'] = $keterangan;
+        }
+        $this->Booking_model->update($id, $data);
         $this->session->set_flashdata('success', 'Status booking diperbarui.');
         redirect('booking');
+    }
+
+    /**
+     * Tampilkan daftar booking yang dibatalkan.
+     */
+    public function cancelled()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+
+        $role = $this->session->userdata('role');
+        if (!in_array($role, ['kasir', 'admin_keuangan', 'owner'])) {
+            show_error('Forbidden', 403);
+        }
+
+        $date = $this->input->get('date');
+        if (!$date) {
+            $date = $this->input->get('tanggal');
+        }
+
+        $data['date'] = $date;
+        $data['bookings'] = !empty($date) ? $this->Booking_model->get_cancelled($date) : [];
+
+        $this->load->view('booking/cancelled', $data);
     }
 }

--- a/application/controllers/Finance.php
+++ b/application/controllers/Finance.php
@@ -2,7 +2,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
- * Controller laporan keuangan untuk admin_keuangan dan owner.
+ * Controller laporan keuangan untuk kasir, admin_keuangan dan owner.
  */
 class Finance extends CI_Controller
 {
@@ -20,13 +20,13 @@ class Finance extends CI_Controller
             redirect('auth/login');
         }
         $role = $this->session->userdata('role');
-        if (!in_array($role, ['admin_keuangan','owner'])) {
+        if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
             redirect('dashboard');
         }
     }
 
     /**
-     * Menampilkan laporan ringkas berdasarkan rentang tanggal.
+     * Menampilkan laporan keuangan detail berdasarkan rentang tanggal.
      */
     public function index()
     {
@@ -41,7 +41,7 @@ class Finance extends CI_Controller
         }
         $data['start_date'] = $start;
         $data['end_date'] = $end;
-        $data['report'] = $this->Report_model->get_financial_summary($start, $end);
+        $data['report'] = $this->Report_model->get_financial_report($start, $end);
         $this->load->view('finance/index', $data);
     }
 }

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -1,0 +1,114 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk manajemen pengguna dan profil.
+ */
+class Users extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('User_model');
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+    }
+
+    /**
+     * Daftar semua pengguna (owner saja).
+     */
+    public function index()
+    {
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $data['users'] = $this->User_model->get_all();
+        $this->load->view('users/index', $data);
+    }
+
+    /**
+     * Owner only: edit data user lain, termasuk mengganti password dan role.
+     */
+    public function edit($id)
+    {
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+
+        // Gunakan logika yang sama dengan profile() tetapi memaksa ID yang dipilih
+        return $this->profile($id);
+    }
+
+    /**
+     * Edit profil pengguna. Jika $id null, edit profil sendiri.
+     * Owner dapat mengedit semua user termasuk role.
+     */
+    public function profile($id = NULL)
+    {
+        $current_id = $this->session->userdata('id');
+        $current_role = $this->session->userdata('role');
+
+        if ($id === NULL) {
+            $id = $current_id;
+        } elseif ($current_role !== 'owner' && (int)$id !== (int)$current_id) {
+            show_error('Forbidden', 403);
+        }
+
+        $user = $this->User_model->get_by_id($id);
+        if (!$user) {
+            show_404();
+        }
+
+        if ($this->input->method() === 'post') {
+            $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
+            $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+            if ($this->input->post('password')) {
+                $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
+            }
+            if ($current_role === 'owner') {
+                $this->form_validation->set_rules('role', 'Role', 'required|in_list[pelanggan,kasir,admin_keuangan,owner]');
+            }
+            if ($this->form_validation->run() === TRUE) {
+                $update = [
+                    'nama_lengkap' => $this->input->post('nama_lengkap', TRUE),
+                    'email'        => $this->input->post('email', TRUE),
+                    'no_telepon'   => $this->input->post('no_telepon', TRUE)
+                ];
+                if ($this->input->post('password')) {
+                    $update['password'] = password_hash($this->input->post('password'), PASSWORD_DEFAULT);
+                }
+                if ($current_role === 'owner') {
+                    $update['role'] = $this->input->post('role', TRUE);
+                }
+                $this->User_model->update($id, $update);
+
+                // perbarui session jika mengubah diri sendiri
+                if ((int)$id === (int)$current_id) {
+                    $session_update = [
+                        'nama_lengkap' => $update['nama_lengkap'],
+                        'email'        => $update['email']
+                    ];
+                    if ($current_role === 'owner' && isset($update['role'])) {
+                        $session_update['role'] = $update['role'];
+                    }
+                    $this->session->set_userdata($session_update);
+                }
+
+                $this->session->set_flashdata('success', 'Profil berhasil diperbarui.');
+                if ($current_role === 'owner' && (int)$id !== (int)$current_id) {
+                    redirect('users');
+                } else {
+                    redirect('users/profile');
+                }
+                return;
+            }
+        }
+
+        $data['user'] = $user;
+        $data['editing_self'] = ((int)$id === (int)$current_id);
+        $this->load->view('users/profile', $data);
+    }
+}

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -10,12 +10,42 @@ class Booking_model extends CI_Model
 
     public function get_by_date($date)
     {
-        return $this->db->get_where($this->table, ['tanggal_booking' => $date])->result();
+        $this->db->where('tanggal_booking', $date);
+        $this->db->where('status_booking !=', 'batal');
+        return $this->db->get($this->table)->result();
     }
 
     public function insert($data)
     {
         return $this->db->insert($this->table, $data);
+    }
+
+    /**
+     * Ambil semua booking milik pengguna tertentu.
+     */
+    public function get_by_user($id_user)
+    {
+        return $this->db->select('bookings.*, courts.nama_lapangan')
+                        ->from($this->table)
+                        ->join('courts', 'courts.id = bookings.id_court')
+                        ->where('bookings.id_user', $id_user)
+                        ->order_by('tanggal_booking', 'desc')
+                        ->get()
+                        ->result();
+    }
+
+    /**
+     * Ambil daftar booking yang dibatalkan.
+     */
+    public function get_cancelled($date = null)
+    {
+        $this->db->where('status_booking', 'batal');
+        if (!empty($date)) {
+            $this->db->where('tanggal_booking', $date);
+        }
+        return $this->db->order_by('tanggal_booking', 'desc')
+                        ->get($this->table)
+                        ->result();
     }
 
     /**
@@ -28,12 +58,16 @@ class Booking_model extends CI_Model
          * Cek ketersediaan jadwal. Bentrok jika rentang waktu overlap:
          * tidak bentrok jika (jam_selesai <= start) OR (jam_mulai >= end)
          * maka kondisi bentrok adalah negasi dari kondisi tersebut.
+         * Abaikan booking yang sudah dibatalkan.
          */
         $this->db->where('id_court', $id_court);
         $this->db->where('tanggal_booking', $date);
-        $this->db->where("NOT (jam_selesai <= '{$start}' OR jam_mulai >= '{$end}')", NULL, FALSE);
-        $conflict = $this->db->get($this->table)->num_rows();
-        return $conflict == 0;
+        $this->db->where('status_booking !=', 'batal');
+        $this->db->group_start();
+        $this->db->where('jam_selesai >', $start);
+        $this->db->where('jam_mulai <', $end);
+        $this->db->group_end();
+        return $this->db->get($this->table)->num_rows() === 0;
     }
 
     /**

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -35,6 +35,74 @@ class Report_model extends CI_Model
     }
 
     /**
+     * Mengambil detail pemasukan dan pengeluaran berdasarkan booking dan penjualan.
+     *
+     * @param string $start Tanggal awal (YYYY-MM-DD)
+     * @param string $end   Tanggal akhir (YYYY-MM-DD)
+     * @return array        Detail transaksi dan total uang masuk/keluar
+     */
+    public function get_financial_report($start, $end)
+    {
+        $details = [];
+
+        // Booking: hanya status confirmed/selesai masuk, batal sebagai uang keluar
+        $this->db->select('id, tanggal_booking, total_harga, status_booking');
+        $this->db->from('bookings');
+        $this->db->where('tanggal_booking >=', $start);
+        $this->db->where('tanggal_booking <=', $end);
+        $bookings = $this->db->get()->result();
+
+        foreach ($bookings as $b) {
+            if (in_array($b->status_booking, ['confirmed', 'selesai'])) {
+                $details[] = [
+                    'tanggal'     => $b->tanggal_booking,
+                    'keterangan'  => 'Booking #' . $b->id,
+                    'uang_masuk'  => (float) $b->total_harga,
+                    'uang_keluar' => 0,
+                ];
+            } elseif ($b->status_booking === 'batal') {
+                $details[] = [
+                    'tanggal'     => $b->tanggal_booking,
+                    'keterangan'  => 'Booking batal #' . $b->id,
+                    'uang_masuk'  => 0,
+                    'uang_keluar' => (float) $b->total_harga,
+                ];
+            }
+        }
+
+        // Penjualan produk masuk sebagai uang masuk
+        $this->db->select('id, total_belanja, tanggal_transaksi');
+        $this->db->from('sales');
+        $this->db->where('tanggal_transaksi >=', $start);
+        $this->db->where('tanggal_transaksi <=', $end . ' 23:59:59');
+        $sales = $this->db->get()->result();
+
+        foreach ($sales as $s) {
+            $details[] = [
+                'tanggal'     => date('Y-m-d', strtotime($s->tanggal_transaksi)),
+                'keterangan'  => 'Penjualan #' . $s->id,
+                'uang_masuk'  => (float) $s->total_belanja,
+                'uang_keluar' => 0,
+            ];
+        }
+
+        // Urutkan berdasarkan tanggal
+        usort($details, function ($a, $b) {
+            return strcmp($a['tanggal'], $b['tanggal']);
+        });
+
+        $total_masuk  = array_sum(array_column($details, 'uang_masuk'));
+        $total_keluar = array_sum(array_column($details, 'uang_keluar'));
+
+        return [
+            'details'      => $details,
+            'total_masuk'  => $total_masuk,
+            'total_keluar' => $total_keluar,
+            'saldo'        => $total_masuk - $total_keluar,
+        ];
+    }
+
+    /**
      * Ringkasan bisnis untuk owner: jumlah booking, jumlah pelanggan, dan produk terlaris.
      */
     public function get_business_summary($start, $end)

--- a/application/views/booking/cancelled.php
+++ b/application/views/booking/cancelled.php
@@ -1,0 +1,38 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Booking Batal</h2>
+
+<form method="get" action="<?php echo site_url('booking/cancelled'); ?>" class="form-inline mb-3">
+    <label for="date" class="mr-2">Tanggal:</label>
+    <input type="date" id="date" name="date" class="form-control mr-2" value="<?php echo htmlspecialchars($date); ?>">
+    <button type="submit" class="btn btn-primary">Lihat</button>
+</form>
+
+<?php if (!empty($bookings)): ?>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Lapangan</th>
+                <th>Pelanggan</th>
+                <th>Jam Mulai</th>
+                <th>Jam Selesai</th>
+                <th>Keterangan</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($bookings as $b): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($b->id_court); ?></td>
+                <td><?php echo htmlspecialchars($b->id_user); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
+                <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php elseif ($date): ?>
+    <p>Tidak ada booking batal pada tanggal ini.</p>
+<?php else: ?>
+    <p>Silakan pilih tanggal.</p>
+<?php endif; ?>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -17,6 +17,7 @@
                 <th>Jam Mulai</th>
                 <th>Jam Selesai</th>
                 <th>Status</th>
+                <th>Keterangan</th>
                 <?php if ($role === 'kasir'): ?>
                     <th>Aksi</th>
                 <?php endif; ?>
@@ -30,6 +31,7 @@
                 <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
+                <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
                     <td>
                         <?php if ($b->status_booking === 'pending'): ?>
@@ -38,17 +40,15 @@
                                 <button type="submit" class="btn btn-sm btn-primary">Confirm</button>
                             </form>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="hidden" name="status" value="batal">
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php elseif ($b->status_booking === 'confirmed'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="completed">
-                                <button type="submit" class="btn btn-sm btn-success">Complete</button>
-                            </form>
-                            <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
-                                <input type="hidden" name="status" value="cancelled">
-                                <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                                <input type="text" name="keterangan" class="form-control form-control-sm mb-1" placeholder="Keterangan" value="<?php echo htmlspecialchars($b->keterangan); ?>">
+                                <button type="submit" name="status" value="selesai" class="btn btn-sm btn-success">Selesai</button>
+                                <button type="submit" name="status" value="batal" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
                     </td>

--- a/application/views/booking/my.php
+++ b/application/views/booking/my.php
@@ -1,0 +1,33 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Booking Saya</h2>
+<a href="<?php echo site_url('booking/create'); ?>" class="btn btn-success mb-3">Booking Baru</a>
+<?php if (empty($bookings)): ?>
+    <p>Belum ada booking.</p>
+<?php else: ?>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Tanggal</th>
+            <th>Lapangan</th>
+            <th>Jam Mulai</th>
+            <th>Jam Selesai</th>
+            <th>Status</th>
+            <th>Keterangan</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($bookings as $b): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($b->tanggal_booking); ?></td>
+            <td><?php echo htmlspecialchars($b->nama_lapangan); ?></td>
+            <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
+            <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
+            <td><?php echo htmlspecialchars(ucfirst($b->status_booking)); ?></td>
+            <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif; ?>
+<?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/finance/index.php
+++ b/application/views/finance/index.php
@@ -9,18 +9,42 @@
 </form>
 
 <table class="table table-bordered">
-    <tr>
-        <th>Total Pendapatan Booking</th>
-        <td>Rp <?php echo number_format($report['total_booking'], 0, ',', '.'); ?></td>
-    </tr>
-    <tr>
-        <th>Total Penjualan F&B</th>
-        <td>Rp <?php echo number_format($report['total_sales'], 0, ',', '.'); ?></td>
-    </tr>
-    <tr>
-        <th>Grand Total</th>
-        <td><strong>Rp <?php echo number_format($report['grand_total'], 0, ',', '.'); ?></strong></td>
-    </tr>
+    <thead>
+        <tr>
+            <th>Tanggal</th>
+            <th>Keterangan</th>
+            <th>Uang Masuk</th>
+            <th>Uang Keluar</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if (!empty($report['details'])): ?>
+        <?php foreach ($report['details'] as $row): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
+            <td><?php echo htmlspecialchars($row['keterangan']); ?></td>
+            <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+            <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    <?php else: ?>
+        <tr>
+            <td colspan="4" class="text-center">Tidak ada data</td>
+        </tr>
+    <?php endif; ?>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th colspan="2">Total</th>
+            <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+            <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+        </tr>
+        <tr>
+            <th colspan="2">Saldo</th>
+            <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+        </tr>
+    </tfoot>
 </table>
 
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -17,15 +17,27 @@
         <ul class="navbar-nav mr-auto">
             <?php if ($this->session->userdata('logged_in')): ?>
                 <?php $role = $this->session->userdata('role'); ?>
-                <li class="nav-item"><a class="nav-link" href="<?php echo site_url('booking'); ?>">Booking</a></li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="bookingDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Booking</a>
+                    <div class="dropdown-menu" aria-labelledby="bookingDropdown">
+                        <?php if ($role === 'pelanggan'): ?>
+                            <a class="dropdown-item" href="<?php echo site_url('booking/my'); ?>">Booking Saya</a>
+                        <?php endif; ?>
+                        <a class="dropdown-item" href="<?php echo site_url('booking'); ?>">Jadwal Booking Lapangan</a>
+                        <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
+                            <a class="dropdown-item" href="<?php echo site_url('booking/cancelled'); ?>">Booking Batal</a>
+                        <?php endif; ?>
+                    </div>
+                </li>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('pos'); ?>">POS</a></li>
                 <?php endif; ?>
                 <?php if ($role === 'owner'): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('courts'); ?>">Lapangan</a></li>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('reports'); ?>">Laporan</a></li>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users'); ?>">Users</a></li>
                 <?php endif; ?>
-                <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
+                <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('finance'); ?>">Keuangan</a></li>
                 <?php endif; ?>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
@@ -36,6 +48,7 @@
         <ul class="navbar-nav">
             <?php if ($this->session->userdata('logged_in')): ?>
                 <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
+                <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users/profile'); ?>">Profil</a></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/logout'); ?>">Logout</a></li>
             <?php else: ?>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/login'); ?>">Login</a></li>

--- a/application/views/users/index.php
+++ b/application/views/users/index.php
@@ -1,0 +1,23 @@
+<?php $this->load->view('templates/header'); ?>
+<h1>Daftar Pengguna</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Nama</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($users as $u): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($u->nama_lengkap); ?></td>
+            <td><?php echo htmlspecialchars($u->email); ?></td>
+            <td><?php echo htmlspecialchars($u->role); ?></td>
+            <td><a href="<?php echo site_url('users/edit/'.$u->id); ?>" class="btn btn-sm btn-primary">Edit</a></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/users/profile.php
+++ b/application/views/users/profile.php
@@ -1,0 +1,36 @@
+<?php $this->load->view('templates/header'); ?>
+<h1><?php echo !empty($editing_self) ? 'Edit Profil' : 'Edit User'; ?></h1>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<?php echo form_open(); ?>
+<div class="form-group">
+    <label>Nama Lengkap</label>
+    <input type="text" name="nama_lengkap" class="form-control" value="<?php echo set_value('nama_lengkap', $user->nama_lengkap); ?>">
+</div>
+<div class="form-group">
+    <label>Email</label>
+    <input type="email" name="email" class="form-control" value="<?php echo set_value('email', $user->email); ?>">
+</div>
+<div class="form-group">
+    <label>No Telepon</label>
+    <input type="text" name="no_telepon" class="form-control" value="<?php echo set_value('no_telepon', $user->no_telepon); ?>">
+</div>
+<div class="form-group">
+    <label>Password (kosongkan jika tidak ganti)</label>
+    <input type="password" name="password" class="form-control">
+</div>
+<?php if ($this->session->userdata('role') === 'owner'): ?>
+<div class="form-group">
+    <label>Role</label>
+    <select name="role" class="form-control">
+        <?php $roles = ['pelanggan' => 'Pelanggan', 'kasir' => 'Kasir', 'admin_keuangan' => 'Admin Keuangan', 'owner' => 'Owner']; ?>
+        <?php foreach ($roles as $key => $label): ?>
+            <option value="<?php echo $key; ?>" <?php echo set_select('role', $key, $user->role === $key); ?>><?php echo $label; ?></option>
+        <?php endforeach; ?>
+    </select>
+</div>
+<?php endif; ?>
+<button type="submit" class="btn btn-primary">Simpan</button>
+<?php echo form_close(); ?>
+<?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
## Summary
- add `get_by_user` model helper and controller action to list a customer's own bookings
- expose "Booking Saya" link in the navbar for customer role and add dedicated view
- restrict "Booking Batal" menu and page access to cashier, finance admin, and owner roles
- allow cashier role to open the finance reports menu
- introduce profile editing pages so users can update their details while only owners may change roles
- provide owners a dedicated edit route for updating any user's password and role
- implement detailed finance report with separate incoming/outgoing columns, counting only confirmed bookings and product sales as income and cancelled bookings as expenses

## Testing
- `php -l application/models/Booking_model.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/booking/my.php`
- `php -l application/views/booking/cancelled.php`
- `php -l application/views/booking/index.php`
- `php -l application/controllers/Finance.php`
- `php -l application/views/finance/index.php`
- `php -l application/controllers/Users.php`
- `php -l application/views/users/index.php`
- `php -l application/views/users/profile.php`
- `php -l application/models/Report_model.php`
- `php -l application/views/finance/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a83cdbf0c48320a3dd4e7ff923a0ad