### PR TITLE
Display store date from database in header

### DIFF
--- a/application/models/Store_status_model.php
+++ b/application/models/Store_status_model.php
@@ -1,0 +1,19 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Store_status_model extends CI_Model
+{
+    protected $table = 'store_status';
+
+    /**
+     * Ambil tanggal toko terakhir.
+     */
+    public function get_store_date()
+    {
+        $row = $this->db->select('store_date')
+                        ->order_by('store_date', 'DESC')
+                        ->get($this->table, 1)
+                        ->row();
+        return $row ? $row->store_date : NULL;
+    }
+}

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -1,3 +1,9 @@
+<?php
+$ci =& get_instance();
+$ci->load->model('Store_status_model');
+$store_date = $ci->Store_status_model->get_store_date();
+$formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : date('d-m-Y');
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -54,6 +60,11 @@
         </ul>
         <ul class="navbar-nav">
             <?php if ($this->session->userdata('logged_in')): ?>
+                <li class="nav-item">
+                    <span class="navbar-text mr-3 px-2 py-1 border rounded d-inline-block">
+                        Tanggal Toko: <?php echo htmlspecialchars($formatted_store_date); ?>
+                    </span>
+                </li>
                 <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users/profile'); ?>">Profil</a></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/logout'); ?>">Logout</a></li>

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS kresnog2_padel_db;
+USE kresnog2_padel_db;
+
+CREATE TABLE cash_transactions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  tanggal DATETIME NOT NULL,
+  type ENUM('in','out') NOT NULL,
+  category ENUM('BON OPERASIONAL','BON TRANSFER BANK','DEBIT CREDIT CARD','MODAL') NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  note TEXT
+);


### PR DESCRIPTION
## Summary
- fetch store date from `store_status` table and show it in the navbar before the user greeting
- add `Store_status_model` for retrieving the latest store date

## Testing
- `php -l application/views/templates/header.php`
- `php -l application/models/Store_status_model.php`
- `phpunit --version` *(fails: command not found)*
- `mysql --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bbddbb083208bf0d66dc106d628