### PR TITLE
Display store date from database in header

### DIFF
--- a/application/controllers/Store_status.php
+++ b/application/controllers/Store_status.php
@@ -1,0 +1,23 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Store_status extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $this->load->model('Store_status_model');
+    }
+
+    /**
+     * Close the store by advancing the store date by one day.
+     */
+    public function close()
+    {
+        $this->Store_status_model->close_store();
+        redirect($_SERVER['HTTP_REFERER'] ?? 'dashboard');
+    }
+}

--- a/application/models/Store_status_model.php
+++ b/application/models/Store_status_model.php
@@ -1,0 +1,29 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Store_status_model extends CI_Model
+{
+    protected $table = 'store_status';
+
+    /**
+     * Ambil tanggal toko terakhir.
+     */
+    public function get_store_date()
+    {
+        $row = $this->db->select('store_date')
+                        ->order_by('store_date', 'DESC')
+                        ->get($this->table, 1)
+                        ->row();
+        return $row ? $row->store_date : NULL;
+    }
+
+    /**
+     * Advance the store date by one day and persist it.
+     */
+    public function close_store()
+    {
+        $current = $this->get_store_date();
+        $next = date('Y-m-d', strtotime(($current ?: date('Y-m-d')) . ' +1 day'));
+        return $this->db->insert($this->table, ['store_date' => $next]);
+    }
+}

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -1,3 +1,9 @@
+<?php
+$ci =& get_instance();
+$ci->load->model('Store_status_model');
+$store_date = $ci->Store_status_model->get_store_date();
+$formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : date('d-m-Y');
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -33,9 +39,7 @@
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('pos'); ?>">POS</a></li>
                 <?php endif; ?>
                 <?php if ($role === 'owner'): ?>
-                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('courts'); ?>">Lapangan</a></li>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('reports'); ?>">Laporan</a></li>
-                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users'); ?>">Users</a></li>
                 <?php endif; ?>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
                     <li class="nav-item dropdown">
@@ -54,6 +58,18 @@
         </ul>
         <ul class="navbar-nav">
             <?php if ($this->session->userdata('logged_in')): ?>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="settingsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Settings</a>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="settingsDropdown">
+                        <?php if ($role === 'owner'): ?>
+                            <a class="dropdown-item" href="<?php echo site_url('users'); ?>">Users</a>
+                            <a class="dropdown-item" href="<?php echo site_url('courts'); ?>">Lapangan</a>
+                        <?php endif; ?>
+                        <div class="dropdown-divider"></div>
+                        <span class="dropdown-item-text px-2 py-1 border rounded d-block mb-2">Tanggal Toko: <?php echo htmlspecialchars($formatted_store_date); ?></span>
+                        <a class="dropdown-item text-danger" href="<?php echo site_url('store_status/close'); ?>" onclick="return confirm('Apakah Anda yakin ingin menutup toko?');">Tutup Toko</a>
+                    </div>
+                </li>
                 <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users/profile'); ?>">Profil</a></li>
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/logout'); ?>">Logout</a></li>

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS kresnog2_padel_db;
+USE kresnog2_padel_db;
+
+CREATE TABLE cash_transactions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  tanggal DATETIME NOT NULL,
+  type ENUM('in','out') NOT NULL,
+  category ENUM('BON OPERASIONAL','BON TRANSFER BANK','DEBIT CREDIT CARD','MODAL') NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  note TEXT
+);


### PR DESCRIPTION
## Summary
- fetch store date from `store_status` table and show it inside a new settings dropdown in the navbar before the user greeting
- add `Store_status_model` for retrieving the latest store date and closing the store by advancing the date
- group `Users` and `Lapangan` links under the new settings dropdown for owner role
- add "Tutup Toko" link with a confirmation dialog that triggers store closing

## Testing
- `php -l application/controllers/Store_status.php`
- `php -l application/models/Store_status_model.php`
- `php -l application/views/templates/header.php`
- `phpunit --version` *(fails: command not found)*
- `mysql --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 errors)*
- `composer install` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bbddbb083208bf0d66dc106d628