### PR TITLE
feat: add store date overlay protections

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -43,6 +43,7 @@ class Booking extends CI_Controller
             redirect('auth/login');
         }
         $data['courts'] = $this->Court_model->get_all();
+        $data['store']  = $this->Store_model->get_current();
         $this->load->view('booking/create', $data);
     }
 

--- a/application/controllers/Cash.php
+++ b/application/controllers/Cash.php
@@ -42,7 +42,8 @@ class Cash extends CI_Controller
             }
             redirect('cash/add');
         }
-        $this->load->view('cash/add');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/add', $data);
     }
 
     public function withdraw()
@@ -65,6 +66,7 @@ class Cash extends CI_Controller
             }
             redirect('cash/withdraw');
         }
-        $this->load->view('cash/withdraw');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/withdraw', $data);
     }
 }

--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -37,6 +37,7 @@ class Pos extends CI_Controller
         foreach ($data['cart'] as $item) {
             $data['total'] += $item['harga_jual'] * $item['qty'];
         }
+        $data['store'] = $this->Store_model->get_current();
         $this->load->view('pos/index', $data);
     }
 

--- a/application/models/Store_model.php
+++ b/application/models/Store_model.php
@@ -33,7 +33,13 @@ class Store_model extends CI_Model
     public function validate_device_date($device_date)
     {
         $current = $this->get_current();
-        if (!$current || !$current->is_open) {
+        if (!$current) {
+            return 'Toko belum dibuka';
+        }
+        if ($current->is_open && $current->store_date < $device_date) {
+            return 'Toko belum ditutup';
+        }
+        if (!$current->is_open) {
             return 'Toko belum dibuka';
         }
         if ($current->store_date !== $device_date) {

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Booking Baru</h2>
 <?php if ($this->session->flashdata('error')): ?>
     <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>

--- a/application/views/cash/add.php
+++ b/application/views/cash/add.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Tambah Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>

--- a/application/views/cash/withdraw.php
+++ b/application/views/cash/withdraw.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Ambil Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Point of Sale</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>

--- a/application/views/store/overlay.php
+++ b/application/views/store/overlay.php
@@ -1,0 +1,28 @@
+<div id="store-block" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);color:#fff;z-index:9999;align-items:center;justify-content:center;text-align:center;">
+    <div>
+        <p id="store-block-message" style="font-size:1.5em;"></p>
+        <?php if ($this->session->userdata('role') !== 'pelanggan'): ?>
+            <a href="<?php echo site_url('store'); ?>" class="btn btn-light mt-3">Pengaturan Tanggal Toko</a>
+        <?php endif; ?>
+    </div>
+</div>
+<script>
+(function(){
+    var storeDate = '<?php echo isset($store->store_date) ? $store->store_date : ''; ?>';
+    var isOpen = <?php echo isset($store->is_open) && $store->is_open ? 'true' : 'false'; ?>;
+    var deviceDate = new Date().toISOString().slice(0,10);
+    var message = '';
+    if (!isOpen) {
+        message = 'Toko belum dibuka';
+    } else if (storeDate < deviceDate) {
+        message = 'Toko belum ditutup';
+    } else if (storeDate !== deviceDate) {
+        message = 'Tanggal perangkat tidak sesuai dengan tanggal toko';
+    }
+    if (message) {
+        var overlay = document.getElementById('store-block');
+        document.getElementById('store-block-message').innerText = message;
+        overlay.style.display = 'flex';
+    }
+})();
+</script>


### PR DESCRIPTION
## Summary
- add `validate_device_date` checks for unclosed stores
- block booking, POS, and cash pages with overlay and redirect to store date screen

## Testing
- `php -l application/models/Store_model.php && php -l application/controllers/Pos.php && php -l application/controllers/Booking.php && php -l application/controllers/Cash.php && php -l application/views/booking/create.php && php -l application/views/pos/index.php && php -l application/views/cash/add.php && php -l application/views/cash/withdraw.php && php -l application/views/store/overlay.php`


------
https://chatgpt.com/codex/tasks/task_e_68aca7c4ffc083209bc1c65437a885b5