### PR TITLE
feat: add store date overlay protections

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -43,6 +43,7 @@ class Booking extends CI_Controller
             redirect('auth/login');
         }
         $data['courts'] = $this->Court_model->get_all();
+        $data['store']  = $this->Store_model->get_current();
         $this->load->view('booking/create', $data);
     }
 

--- a/application/controllers/Cash.php
+++ b/application/controllers/Cash.php
@@ -42,7 +42,8 @@ class Cash extends CI_Controller
             }
             redirect('cash/add');
         }
-        $this->load->view('cash/add');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/add', $data);
     }
 
     public function withdraw()
@@ -65,6 +66,7 @@ class Cash extends CI_Controller
             }
             redirect('cash/withdraw');
         }
-        $this->load->view('cash/withdraw');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/withdraw', $data);
     }
 }

--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -37,6 +37,7 @@ class Pos extends CI_Controller
         foreach ($data['cart'] as $item) {
             $data['total'] += $item['harga_jual'] * $item['qty'];
         }
+        $data['store'] = $this->Store_model->get_current();
         $this->load->view('pos/index', $data);
     }
 

--- a/application/controllers/Store.php
+++ b/application/controllers/Store.php
@@ -32,16 +32,19 @@ class Store extends CI_Controller
     public function open()
     {
         $this->authorize();
-        $date = $this->input->post('store_date');
+        $date    = $this->input->post('store_date');
+        $current = $this->Store_model->get_current();
+        if (!$date && $current) {
+            $date = $current->store_date;
+        }
         if (!$date) {
             $date = date('Y-m-d');
         }
-        $current = $this->Store_model->get_current();
         if ($current && $current->is_open) {
             $this->session->set_flashdata('error', 'Toko sudah dibuka.');
         } else {
             $this->Store_model->open($date);
-            $this->session->set_flashdata('success', 'Tanggal toko dibuka.');
+            $this->session->set_flashdata('success', 'Toko dibuka pada tanggal: ' . $date);
         }
         redirect('store');
     }
@@ -53,8 +56,8 @@ class Store extends CI_Controller
         if (!$current || !$current->is_open) {
             $this->session->set_flashdata('error', 'Toko belum dibuka.');
         } else {
-            $this->Store_model->close();
-            $this->session->set_flashdata('success', 'Toko ditutup.');
+            $next = $this->Store_model->close();
+            $this->session->set_flashdata('success', 'Toko ditutup pada tanggal: ' . $current->store_date . '. Tanggal berikutnya: ' . $next);
         }
         redirect('store');
     }

--- a/application/models/Store_model.php
+++ b/application/models/Store_model.php
@@ -12,6 +12,15 @@ class Store_model extends CI_Model
 
     public function open($date)
     {
+        $current = $this->get_current();
+        if ($current) {
+            return $this->db->where('id', $current->id)
+                            ->update($this->table, [
+                                'store_date' => $date,
+                                'is_open'    => 1,
+                                'closed_at'  => NULL
+                            ]);
+        }
         return $this->db->insert($this->table, [
             'store_date' => $date,
             'is_open'    => 1
@@ -22,18 +31,28 @@ class Store_model extends CI_Model
     {
         $current = $this->get_current();
         if ($current && $current->is_open) {
+            $next_date = date('Y-m-d', strtotime($current->store_date . ' +1 day'));
             $this->db->where('id', $current->id)
                      ->update($this->table, [
-                         'is_open'   => 0,
-                         'closed_at' => date('Y-m-d H:i:s')
+                         'is_open'    => 0,
+                         'closed_at'  => date('Y-m-d H:i:s'),
+                         'store_date' => $next_date
                      ]);
+            return $next_date;
         }
+        return NULL;
     }
 
     public function validate_device_date($device_date)
     {
         $current = $this->get_current();
-        if (!$current || !$current->is_open) {
+        if (!$current) {
+            return 'Toko belum dibuka';
+        }
+        if ($current->is_open && $current->store_date < $device_date) {
+            return 'Toko belum ditutup';
+        }
+        if (!$current->is_open) {
             return 'Toko belum dibuka';
         }
         if ($current->store_date !== $device_date) {

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Booking Baru</h2>
 <?php if ($this->session->flashdata('error')): ?>
     <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
@@ -31,6 +32,7 @@
     <a href="<?php echo site_url('booking'); ?>" class="btn btn-secondary">Batal</a>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/cash/add.php
+++ b/application/views/cash/add.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Tambah Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -28,6 +29,8 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/cash/withdraw.php
+++ b/application/views/cash/withdraw.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Ambil Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -28,6 +29,8 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Point of Sale</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -62,6 +63,10 @@
 </div>
 
 <script>
-document.getElementById('device_date') && (document.getElementById('device_date').value = new Date().toISOString().slice(0,10));
+var deviceInput = document.getElementById('device_date');
+if (deviceInput) {
+    var now = new Date();
+    deviceInput.value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+}
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/store/index.php
+++ b/application/views/store/index.php
@@ -7,15 +7,16 @@
     <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
 <?php endif; ?>
 <?php if ($store && $store->is_open): ?>
+    <?php $next_date = date('Y-m-d', strtotime($store->store_date . ' +1 day')); ?>
     <p>Toko dibuka pada tanggal: <strong><?php echo $store->store_date; ?></strong></p>
     <form method="post" action="<?php echo site_url('store/close'); ?>">
-        <button type="submit" class="btn btn-danger">Tutup Toko</button>
+        <button type="submit" class="btn btn-danger" onclick="return confirm('Tutup toko pada tanggal <?php echo $store->store_date; ?>? Tanggal berikutnya: <?php echo $next_date; ?>');">Tutup Toko</button>
     </form>
 <?php else: ?>
-    <form method="post" action="<?php echo site_url('store/open'); ?>">
+    <form method="post" action="<?php echo site_url('store/open'); ?>" onsubmit="return confirm('Buka toko untuk tanggal ' + document.getElementById('store_date').value + '?');">
         <div class="form-group">
             <label for="store_date">Tanggal Toko</label>
-            <input type="date" name="store_date" id="store_date" class="form-control" value="<?php echo date('Y-m-d'); ?>" required>
+            <input type="date" name="store_date" id="store_date" class="form-control" value="<?php echo $store ? $store->store_date : date('Y-m-d'); ?>" required>
         </div>
         <button type="submit" class="btn btn-primary">Buka Toko</button>
     </form>

--- a/application/views/store/overlay.php
+++ b/application/views/store/overlay.php
@@ -1,0 +1,29 @@
+<div id="store-block" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);color:#fff;z-index:9999;align-items:center;justify-content:center;text-align:center;">
+    <div>
+        <p id="store-block-message" style="font-size:1.5em;"></p>
+        <?php if ($this->session->userdata('role') !== 'pelanggan'): ?>
+            <a href="<?php echo site_url('store'); ?>" class="btn btn-light mt-3">Pengaturan Tanggal Toko</a>
+        <?php endif; ?>
+    </div>
+</div>
+<script>
+(function(){
+    var storeDate = '<?php echo isset($store->store_date) ? $store->store_date : ''; ?>';
+    var isOpen = <?php echo isset($store->is_open) && $store->is_open ? 'true' : 'false'; ?>;
+    var now = new Date();
+    var deviceDate = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+    var message = '';
+    if (!isOpen) {
+        message = 'Toko belum dibuka';
+    } else if (storeDate < deviceDate) {
+        message = 'Toko belum ditutup';
+    } else if (storeDate !== deviceDate) {
+        message = 'Tanggal perangkat tidak sesuai dengan tanggal toko';
+    }
+    if (message) {
+        var overlay = document.getElementById('store-block');
+        document.getElementById('store-block-message').innerText = message;
+        overlay.style.display = 'flex';
+    }
+})();
+</script>

--- a/index.php
+++ b/index.php
@@ -53,7 +53,10 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-	define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+       define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+
+// Set default timezone for application
+date_default_timezone_set('Asia/Jakarta');
 
 /*
  *---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `validate_device_date` checks for unclosed stores
- block booking, POS, and cash pages with overlay and redirect to store date screen
- use local device date for validation and overlays
- advance store date on close and prompt confirmation with dates for open/close
- reuse advanced store date when reopening and default to Jakarta timezone

## Testing
- `php -l application/models/Store_model.php && php -l application/controllers/Store.php && php -l application/views/store/index.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aca7c4ffc083209bc1c65437a885b5