### PR TITLE
feat: add store date overlay protections

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -43,6 +43,7 @@ class Booking extends CI_Controller
             redirect('auth/login');
         }
         $data['courts'] = $this->Court_model->get_all();
+        $data['store']  = $this->Store_model->get_current();
         $this->load->view('booking/create', $data);
     }
 

--- a/application/controllers/Cash.php
+++ b/application/controllers/Cash.php
@@ -42,7 +42,8 @@ class Cash extends CI_Controller
             }
             redirect('cash/add');
         }
-        $this->load->view('cash/add');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/add', $data);
     }
 
     public function withdraw()
@@ -65,6 +66,7 @@ class Cash extends CI_Controller
             }
             redirect('cash/withdraw');
         }
-        $this->load->view('cash/withdraw');
+        $data['store'] = $this->Store_model->get_current();
+        $this->load->view('cash/withdraw', $data);
     }
 }

--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -1,0 +1,109 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk manajemen data member (kasir).
+ */
+class Members extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model(['Member_model','User_model']);
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        if ($this->session->userdata('role') !== 'kasir') {
+            redirect('dashboard');
+        }
+    }
+
+    public function index()
+    {
+        $this->authorize();
+        $data['members'] = $this->Member_model->get_all();
+        $this->load->view('members/index', $data);
+    }
+
+    public function create()
+    {
+        $this->authorize();
+        $this->load->view('members/create');
+    }
+
+    public function store()
+    {
+        $this->authorize();
+        $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
+        if ($this->form_validation->run() === TRUE) {
+            $user_data = [
+                'nama_lengkap' => $this->input->post('nama_lengkap', TRUE),
+                'email'        => $this->input->post('email', TRUE),
+                'no_telepon'   => $this->input->post('no_telepon', TRUE),
+                'password'     => password_hash($this->input->post('password'), PASSWORD_DEFAULT),
+                'role'         => 'pelanggan'
+            ];
+            $member_data = [
+                'alamat'    => $this->input->post('alamat', TRUE),
+                'kecamatan' => $this->input->post('kecamatan', TRUE),
+                'kota'      => $this->input->post('kota', TRUE),
+                'provinsi'  => $this->input->post('provinsi', TRUE)
+            ];
+            $this->Member_model->insert($user_data, $member_data);
+            $this->session->set_flashdata('success', 'Member berhasil ditambahkan.');
+            redirect('members');
+            return;
+        }
+        $this->create();
+    }
+
+    public function edit($id)
+    {
+        $this->authorize();
+        $data['member'] = $this->Member_model->get_by_id($id);
+        if (!$data['member']) {
+            show_404();
+        }
+        $this->load->view('members/edit', $data);
+    }
+
+    public function update($id)
+    {
+        $this->authorize();
+        $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        if ($this->form_validation->run() === TRUE) {
+            $user_data = [
+                'nama_lengkap' => $this->input->post('nama_lengkap', TRUE),
+                'email'        => $this->input->post('email', TRUE),
+                'no_telepon'   => $this->input->post('no_telepon', TRUE)
+            ];
+            if ($this->input->post('password')) {
+                $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
+                $user_data['password'] = password_hash($this->input->post('password'), PASSWORD_DEFAULT);
+            }
+            $member_data = [
+                'alamat'    => $this->input->post('alamat', TRUE),
+                'kecamatan' => $this->input->post('kecamatan', TRUE),
+                'kota'      => $this->input->post('kota', TRUE),
+                'provinsi'  => $this->input->post('provinsi', TRUE)
+            ];
+            $this->Member_model->update($id, $user_data, $member_data);
+            $this->session->set_flashdata('success', 'Member berhasil diperbarui.');
+            redirect('members');
+            return;
+        }
+        $this->edit($id);
+    }
+}
+?>

--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -37,6 +37,7 @@ class Pos extends CI_Controller
         foreach ($data['cart'] as $item) {
             $data['total'] += $item['harga_jual'] * $item['qty'];
         }
+        $data['store'] = $this->Store_model->get_current();
         $this->load->view('pos/index', $data);
     }
 

--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -6,6 +6,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 class Products extends CI_Controller
 {
+    private $categories = ['makanan','snack','cofee','non cofee','tea'];
     public function __construct()
     {
         parent::__construct();
@@ -35,7 +36,8 @@ class Products extends CI_Controller
     public function create()
     {
         $this->authorize();
-        $this->load->view('products/create');
+        $data['categories'] = $this->categories;
+        $this->load->view('products/create', $data);
     }
 
     public function store()
@@ -44,6 +46,7 @@ class Products extends CI_Controller
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
+        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $this->categories).']');
         if ($this->form_validation->run() === TRUE) {
             $data = [
                 'nama_produk' => $this->input->post('nama_produk', TRUE),
@@ -63,6 +66,7 @@ class Products extends CI_Controller
     {
         $this->authorize();
         $data['product'] = $this->Product_model->get_by_id($id);
+        $data['categories'] = $this->categories;
         $this->load->view('products/edit', $data);
     }
 
@@ -72,6 +76,7 @@ class Products extends CI_Controller
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
+        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $this->categories).']');
         if ($this->form_validation->run() === TRUE) {
             $data = [
                 'nama_produk' => $this->input->post('nama_produk', TRUE),

--- a/application/controllers/Store.php
+++ b/application/controllers/Store.php
@@ -32,16 +32,20 @@ class Store extends CI_Controller
     public function open()
     {
         $this->authorize();
-        $date = $this->input->post('store_date');
+        $role    = $this->session->userdata('role');
+        $date    = $role === 'owner' ? $this->input->post('store_date') : null;
+        $current = $this->Store_model->get_current();
+        if (!$date && $current) {
+            $date = $current->store_date;
+        }
         if (!$date) {
             $date = date('Y-m-d');
         }
-        $current = $this->Store_model->get_current();
         if ($current && $current->is_open) {
             $this->session->set_flashdata('error', 'Toko sudah dibuka.');
         } else {
             $this->Store_model->open($date);
-            $this->session->set_flashdata('success', 'Tanggal toko dibuka.');
+            $this->session->set_flashdata('success', 'Toko dibuka pada tanggal: ' . $date);
         }
         redirect('store');
     }
@@ -53,8 +57,8 @@ class Store extends CI_Controller
         if (!$current || !$current->is_open) {
             $this->session->set_flashdata('error', 'Toko belum dibuka.');
         } else {
-            $this->Store_model->close();
-            $this->session->set_flashdata('success', 'Toko ditutup.');
+            $next = $this->Store_model->close();
+            $this->session->set_flashdata('success', 'Toko ditutup pada tanggal: ' . $current->store_date . '. Tanggal berikutnya: ' . $next);
         }
         redirect('store');
     }

--- a/application/models/Member_model.php
+++ b/application/models/Member_model.php
@@ -1,0 +1,70 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Model untuk data member tambahan.
+ */
+class Member_model extends CI_Model
+{
+    protected $table = 'member_data';
+
+    /**
+     * Ambil semua data member beserta info user pelanggan.
+     */
+    public function get_all()
+    {
+        $this->db->select('u.id, u.nama_lengkap, u.email, u.no_telepon, m.kode_member, m.alamat, m.kecamatan, m.kota, m.provinsi');
+        $this->db->from('users u');
+        $this->db->join('member_data m', 'm.user_id = u.id', 'left');
+        $this->db->where('u.role', 'pelanggan');
+        return $this->db->get()->result();
+    }
+
+    /**
+     * Ambil satu member berdasarkan ID user.
+     */
+    public function get_by_id($id)
+    {
+        $this->db->select('u.id, u.nama_lengkap, u.email, u.no_telepon, u.password, m.kode_member, m.alamat, m.kecamatan, m.kota, m.provinsi');
+        $this->db->from('users u');
+        $this->db->join('member_data m', 'm.user_id = u.id', 'left');
+        $this->db->where(['u.id' => $id, 'u.role' => 'pelanggan']);
+        return $this->db->get()->row();
+    }
+
+    /**
+     * Insert user dan data member.
+     */
+    public function insert($user_data, $member_data)
+    {
+        $this->db->trans_start();
+        $this->db->insert('users', $user_data);
+        $member_data['user_id'] = $this->db->insert_id();
+        unset($member_data['kode_member']);
+        $member_data['kode_member'] = str_pad($member_data['user_id'], 10, '0', STR_PAD_LEFT);
+        $this->db->insert($this->table, $member_data);
+        $this->db->trans_complete();
+        return $this->db->trans_status();
+    }
+
+    /**
+     * Update user dan data member.
+     */
+    public function update($id, $user_data, $member_data)
+    {
+        $this->db->trans_start();
+        $this->db->where('id', $id)->update('users', $user_data);
+        unset($member_data['kode_member']);
+        $exists = $this->db->get_where($this->table, ['user_id' => $id])->row();
+        if ($exists) {
+            $this->db->where('user_id', $id)->update($this->table, $member_data);
+        } else {
+            $member_data['user_id'] = $id;
+            $member_data['kode_member'] = str_pad($id, 10, '0', STR_PAD_LEFT);
+            $this->db->insert($this->table, $member_data);
+        }
+        $this->db->trans_complete();
+        return $this->db->trans_status();
+    }
+}
+?>

--- a/application/models/Store_model.php
+++ b/application/models/Store_model.php
@@ -12,6 +12,15 @@ class Store_model extends CI_Model
 
     public function open($date)
     {
+        $current = $this->get_current();
+        if ($current) {
+            return $this->db->where('id', $current->id)
+                            ->update($this->table, [
+                                'store_date' => $date,
+                                'is_open'    => 1,
+                                'closed_at'  => NULL
+                            ]);
+        }
         return $this->db->insert($this->table, [
             'store_date' => $date,
             'is_open'    => 1
@@ -22,18 +31,28 @@ class Store_model extends CI_Model
     {
         $current = $this->get_current();
         if ($current && $current->is_open) {
+            $next_date = date('Y-m-d', strtotime($current->store_date . ' +1 day'));
             $this->db->where('id', $current->id)
                      ->update($this->table, [
-                         'is_open'   => 0,
-                         'closed_at' => date('Y-m-d H:i:s')
+                         'is_open'    => 0,
+                         'closed_at'  => date('Y-m-d H:i:s'),
+                         'store_date' => $next_date
                      ]);
+            return $next_date;
         }
+        return NULL;
     }
 
     public function validate_device_date($device_date)
     {
         $current = $this->get_current();
-        if (!$current || !$current->is_open) {
+        if (!$current) {
+            return 'Toko belum dibuka';
+        }
+        if ($current->is_open && $current->store_date < $device_date) {
+            return 'Toko belum ditutup';
+        }
+        if (!$current->is_open) {
             return 'Toko belum dibuka';
         }
         if ($current->store_date !== $device_date) {

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Booking Baru</h2>
 <?php if ($this->session->flashdata('error')): ?>
     <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
@@ -31,6 +32,7 @@
     <a href="<?php echo site_url('booking'); ?>" class="btn btn-secondary">Batal</a>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/cash/add.php
+++ b/application/views/cash/add.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Tambah Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -28,6 +29,8 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/cash/withdraw.php
+++ b/application/views/cash/withdraw.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Ambil Uang Kas</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -28,6 +29,8 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
 </form>
 <script>
-document.getElementById('device_date').value = new Date().toISOString().slice(0,10);
+var now = new Date();
+document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
 </script>
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/members/create.php
+++ b/application/views/members/create.php
@@ -1,0 +1,40 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Tambah Member</h2>
+<?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
+<form method="post" action="<?php echo site_url('members/store'); ?>">
+    <div class="form-group">
+        <label for="nama_lengkap">Nama Lengkap</label>
+        <input type="text" name="nama_lengkap" id="nama_lengkap" class="form-control" value="<?php echo set_value('nama_lengkap'); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="email">Email</label>
+        <input type="email" name="email" id="email" class="form-control" value="<?php echo set_value('email'); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="no_telepon">No Telepon</label>
+        <input type="text" name="no_telepon" id="no_telepon" class="form-control" value="<?php echo set_value('no_telepon'); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="password">Password</label>
+        <input type="password" name="password" id="password" class="form-control" required>
+    </div>
+    <div class="form-group">
+        <label for="alamat">Alamat / Jalan</label>
+        <input type="text" name="alamat" id="alamat" class="form-control" value="<?php echo set_value('alamat'); ?>">
+    </div>
+    <div class="form-group">
+        <label for="kecamatan">Kecamatan</label>
+        <input type="text" name="kecamatan" id="kecamatan" class="form-control" value="<?php echo set_value('kecamatan'); ?>">
+    </div>
+    <div class="form-group">
+        <label for="kota">Kota</label>
+        <input type="text" name="kota" id="kota" class="form-control" value="<?php echo set_value('kota'); ?>">
+    </div>
+    <div class="form-group">
+        <label for="provinsi">Provinsi</label>
+        <input type="text" name="provinsi" id="provinsi" class="form-control" value="<?php echo set_value('provinsi'); ?>">
+    </div>
+    <button type="submit" class="btn btn-primary">Simpan</button>
+    <a href="<?php echo site_url('members'); ?>" class="btn btn-secondary">Batal</a>
+</form>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/members/edit.php
+++ b/application/views/members/edit.php
@@ -1,0 +1,44 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Edit Member</h2>
+<?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
+<form method="post" action="<?php echo site_url('members/update/'.$member->id); ?>">
+    <div class="form-group">
+        <label for="nama_lengkap">Nama Lengkap</label>
+        <input type="text" name="nama_lengkap" id="nama_lengkap" class="form-control" value="<?php echo set_value('nama_lengkap', $member->nama_lengkap); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="email">Email</label>
+        <input type="email" name="email" id="email" class="form-control" value="<?php echo set_value('email', $member->email); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="no_telepon">No Telepon</label>
+        <input type="text" name="no_telepon" id="no_telepon" class="form-control" value="<?php echo set_value('no_telepon', $member->no_telepon); ?>" required>
+    </div>
+    <div class="form-group">
+        <label for="password">Password</label>
+        <input type="password" name="password" id="password" class="form-control" placeholder="Kosongkan jika tidak diubah">
+    </div>
+    <div class="form-group">
+        <label for="kode_member">Kode Member</label>
+        <input type="text" id="kode_member" class="form-control" value="<?php echo $member->kode_member; ?>" readonly>
+    </div>
+    <div class="form-group">
+        <label for="alamat">Alamat / Jalan</label>
+        <input type="text" name="alamat" id="alamat" class="form-control" value="<?php echo set_value('alamat', $member->alamat); ?>">
+    </div>
+    <div class="form-group">
+        <label for="kecamatan">Kecamatan</label>
+        <input type="text" name="kecamatan" id="kecamatan" class="form-control" value="<?php echo set_value('kecamatan', $member->kecamatan); ?>">
+    </div>
+    <div class="form-group">
+        <label for="kota">Kota</label>
+        <input type="text" name="kota" id="kota" class="form-control" value="<?php echo set_value('kota', $member->kota); ?>">
+    </div>
+    <div class="form-group">
+        <label for="provinsi">Provinsi</label>
+        <input type="text" name="provinsi" id="provinsi" class="form-control" value="<?php echo set_value('provinsi', $member->provinsi); ?>">
+    </div>
+    <button type="submit" class="btn btn-primary">Update</button>
+    <a href="<?php echo site_url('members'); ?>" class="btn btn-secondary">Batal</a>
+</form>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/members/index.php
+++ b/application/views/members/index.php
@@ -1,0 +1,37 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Data Member</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<a href="<?php echo site_url('members/create'); ?>" class="btn btn-primary mb-3">Tambah Member</a>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Kode Member</th>
+            <th>Nama</th>
+            <th>Email</th>
+            <th>No Telepon</th>
+            <th>Alamat</th>
+            <th>Kecamatan</th>
+            <th>Kota</th>
+            <th>Provinsi</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($members as $m): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($m->kode_member); ?></td>
+                <td><?php echo htmlspecialchars($m->nama_lengkap); ?></td>
+                <td><?php echo htmlspecialchars($m->email); ?></td>
+                <td><?php echo htmlspecialchars($m->no_telepon); ?></td>
+                <td><?php echo htmlspecialchars($m->alamat); ?></td>
+                <td><?php echo htmlspecialchars($m->kecamatan); ?></td>
+                <td><?php echo htmlspecialchars($m->kota); ?></td>
+                <td><?php echo htmlspecialchars($m->provinsi); ?></td>
+                <td><a href="<?php echo site_url('members/edit/'.$m->id); ?>" class="btn btn-sm btn-warning">Edit</a></td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -1,4 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
 <h2>Point of Sale</h2>
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
@@ -62,6 +63,10 @@
 </div>
 
 <script>
-document.getElementById('device_date') && (document.getElementById('device_date').value = new Date().toISOString().slice(0,10));
+var deviceInput = document.getElementById('device_date');
+if (deviceInput) {
+    var now = new Date();
+    deviceInput.value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+}
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/products/create.php
+++ b/application/views/products/create.php
@@ -16,7 +16,11 @@
     </div>
     <div class="form-group">
         <label for="kategori">Kategori</label>
-        <input type="text" name="kategori" id="kategori" class="form-control" value="<?php echo set_value('kategori'); ?>">
+        <select name="kategori" id="kategori" class="form-control">
+            <?php foreach ($categories as $cat): ?>
+            <option value="<?php echo $cat; ?>" <?php echo set_select('kategori', $cat); ?>><?php echo ucwords($cat); ?></option>
+            <?php endforeach; ?>
+        </select>
     </div>
     <button type="submit" class="btn btn-primary">Simpan</button>
     <a href="<?php echo site_url('products'); ?>" class="btn btn-secondary">Batal</a>

--- a/application/views/products/edit.php
+++ b/application/views/products/edit.php
@@ -16,7 +16,11 @@
     </div>
     <div class="form-group">
         <label for="kategori">Kategori</label>
-        <input type="text" name="kategori" id="kategori" class="form-control" value="<?php echo set_value('kategori', $product->kategori); ?>">
+        <select name="kategori" id="kategori" class="form-control">
+            <?php foreach ($categories as $cat): ?>
+            <option value="<?php echo $cat; ?>" <?php echo set_select('kategori', $cat, $product->kategori === $cat); ?>><?php echo ucwords($cat); ?></option>
+            <?php endforeach; ?>
+        </select>
     </div>
     <button type="submit" class="btn btn-primary">Update</button>
     <a href="<?php echo site_url('products'); ?>" class="btn btn-secondary">Batal</a>

--- a/application/views/store/index.php
+++ b/application/views/store/index.php
@@ -6,17 +6,22 @@
 <?php if ($this->session->flashdata('error')): ?>
     <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
 <?php endif; ?>
+<?php $role = $this->session->userdata('role'); ?>
 <?php if ($store && $store->is_open): ?>
+    <?php $next_date = date('Y-m-d', strtotime($store->store_date . ' +1 day')); ?>
     <p>Toko dibuka pada tanggal: <strong><?php echo $store->store_date; ?></strong></p>
     <form method="post" action="<?php echo site_url('store/close'); ?>">
-        <button type="submit" class="btn btn-danger">Tutup Toko</button>
+        <button type="submit" class="btn btn-danger" onclick="return confirm('Tutup toko pada tanggal <?php echo $store->store_date; ?>? Tanggal berikutnya: <?php echo $next_date; ?>');">Tutup Toko</button>
     </form>
 <?php else: ?>
-    <form method="post" action="<?php echo site_url('store/open'); ?>">
+    <?php $open_date = $store ? $store->store_date : date('Y-m-d'); ?>
+    <form method="post" action="<?php echo site_url('store/open'); ?>" <?php if ($role === 'owner'): ?>onsubmit="return confirm('Buka toko untuk tanggal ' + document.getElementById('store_date').value + '?');"<?php else: ?>onsubmit="return confirm('Buka toko pada tanggal <?php echo $open_date; ?>?');"<?php endif; ?>>
+        <?php if ($role === 'owner'): ?>
         <div class="form-group">
             <label for="store_date">Tanggal Toko</label>
-            <input type="date" name="store_date" id="store_date" class="form-control" value="<?php echo date('Y-m-d'); ?>" required>
+            <input type="date" name="store_date" id="store_date" class="form-control" value="<?php echo $open_date; ?>" required>
         </div>
+        <?php endif; ?>
         <button type="submit" class="btn btn-primary">Buka Toko</button>
     </form>
 <?php endif; ?>

--- a/application/views/store/overlay.php
+++ b/application/views/store/overlay.php
@@ -1,0 +1,29 @@
+<div id="store-block" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);color:#fff;z-index:9999;align-items:center;justify-content:center;text-align:center;">
+    <div>
+        <p id="store-block-message" style="font-size:1.5em;"></p>
+        <?php if ($this->session->userdata('role') !== 'pelanggan'): ?>
+            <a href="<?php echo site_url('store'); ?>" class="btn btn-light mt-3">Pengaturan Tanggal Toko</a>
+        <?php endif; ?>
+    </div>
+</div>
+<script>
+(function(){
+    var storeDate = '<?php echo isset($store->store_date) ? $store->store_date : ''; ?>';
+    var isOpen = <?php echo isset($store->is_open) && $store->is_open ? 'true' : 'false'; ?>;
+    var now = new Date();
+    var deviceDate = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+    var message = '';
+    if (!isOpen) {
+        message = 'Toko belum dibuka';
+    } else if (storeDate < deviceDate) {
+        message = 'Toko belum ditutup';
+    } else if (storeDate !== deviceDate) {
+        message = 'Tanggal perangkat tidak sesuai dengan tanggal toko';
+    }
+    if (message) {
+        var overlay = document.getElementById('store-block');
+        document.getElementById('store-block-message').innerText = message;
+        overlay.style.display = 'flex';
+    }
+})();
+</script>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -36,7 +36,13 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                     </div>
                 </li>
                 <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
-                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('pos'); ?>">POS</a></li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="posDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">POS</a>
+                        <div class="dropdown-menu" aria-labelledby="posDropdown">
+                            <a class="dropdown-item" href="<?php echo site_url('pos'); ?>">Tambah Transaksi</a>
+                            <a class="dropdown-item" href="<?php echo site_url('products'); ?>">Tambah Produk</a>
+                        </div>
+                    </li>
                 <?php endif; ?>
                 <?php if ($role === 'owner'): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('reports'); ?>">Laporan</a></li>
@@ -51,8 +57,8 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                     </li>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('finance'); ?>">Keuangan</a></li>
                 <?php endif; ?>
-                <?php if (in_array($role, ['kasir','admin_keuangan','owner'])): ?>
-                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('products'); ?>">Produk</a></li>
+                <?php if ($role === 'kasir'): ?>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('members'); ?>">Data Member</a></li>
                 <?php endif; ?>
             <?php endif; ?>
 

--- a/database.sql
+++ b/database.sql
@@ -42,7 +42,7 @@ CREATE TABLE products (
   nama_produk VARCHAR(100) NOT NULL,
   harga_jual DECIMAL(10,2) NOT NULL,
   stok INT NOT NULL,
-  kategori VARCHAR(50),
+  kategori ENUM('makanan','snack','cofee','non cofee','tea') NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -95,3 +95,14 @@ CREATE TABLE store_status (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+
+CREATE TABLE member_data (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  kode_member CHAR(10) NOT NULL,
+  alamat VARCHAR(255) DEFAULT NULL,
+  kecamatan VARCHAR(100) DEFAULT NULL,
+  kota VARCHAR(100) DEFAULT NULL,
+  provinsi VARCHAR(100) DEFAULT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/index.php
+++ b/index.php
@@ -53,7 +53,10 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-	define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+       define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+
+// Set default timezone for application
+date_default_timezone_set('Asia/Jakarta');
 
 /*
  *---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `validate_device_date` checks for unclosed stores
- block booking, POS, and cash pages with overlay and redirect to store date screen
- use local device date for validation and overlays
- advance store date on close and prompt confirmation with dates for open/close
- reuse advanced store date when reopening and default to Jakarta timezone
- restrict store opening date selection to owners only, hiding the date picker for others
- add member management menu for cashiers with member address details
- auto-generate 10-digit member codes from user IDs and make them read-only
- merge POS and product links into a single POS dropdown with renamed items
- constrain product categories to makanan, snack, cofee, non cofee, or tea

## Testing
- `php -l application/models/Member_model.php`
- `php -l application/controllers/Members.php`
- `php -l application/views/members/create.php && php -l application/views/members/edit.php && php -l application/views/members/index.php`
- `php -l application/views/templates/header.php`
- `php -l application/controllers/Products.php && php -l application/views/products/create.php && php -l application/views/products/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68aca7c4ffc083209bc1c65437a885b5