### PR TITLE
Add product category filtering and live search to POS

### DIFF
--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -31,7 +31,12 @@ class Pos extends CI_Controller
     public function index()
     {
         $this->authorize();
-        $data['products'] = $this->Product_model->get_all();
+        $kategori = $this->input->get('kategori');
+        $keyword  = $this->input->get('q');
+        $data['products'] = $this->Product_model->get_filtered($kategori, $keyword);
+        $data['categories'] = $this->Product_model->get_categories();
+        $data['selected_category'] = $kategori;
+        $data['search_query'] = $keyword;
         $data['cart'] = $this->session->userdata('cart') ?: [];
         $data['total'] = 0;
         foreach ($data['cart'] as $item) {
@@ -39,6 +44,20 @@ class Pos extends CI_Controller
         }
         $data['store'] = $this->Store_model->get_current();
         $this->load->view('pos/index', $data);
+    }
+
+    /**
+     * Endpoint AJAX untuk mengambil daftar produk terfilter.
+     */
+    public function search()
+    {
+        $this->authorize();
+        $kategori = $this->input->get('kategori');
+        $keyword  = $this->input->get('q');
+        $products = $this->Product_model->get_filtered($kategori, $keyword);
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode($products));
     }
 
     /**
@@ -63,6 +82,33 @@ class Pos extends CI_Controller
             ];
         }
         $this->session->set_userdata('cart', $cart);
+        redirect('pos');
+    }
+
+    /**
+     * Perbarui jumlah masing-masing item di keranjang.
+     */
+    public function update_cart()
+    {
+        $this->authorize();
+        if ($this->input->method() !== 'post') {
+            redirect('pos');
+        }
+        $qtys = $this->input->post('qty');
+        $cart = $this->session->userdata('cart') ?: [];
+        if (is_array($qtys)) {
+            foreach ($qtys as $id => $qty) {
+                if (isset($cart[$id])) {
+                    $qty = (int) $qty;
+                    if ($qty > 0) {
+                        $cart[$id]['qty'] = $qty;
+                    } else {
+                        unset($cart[$id]);
+                    }
+                }
+            }
+            $this->session->set_userdata('cart', $cart);
+        }
         redirect('pos');
     }
 

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -8,8 +8,30 @@ class Product_model extends CI_Model
 {
     protected $table = 'products';
 
+    /**
+     * Ambil semua kategori produk yang tersedia.
+     */
+    public function get_categories()
+    {
+        return $this->db->select('kategori')->distinct()->order_by('kategori')->get($this->table)->result();
+    }
+
     public function get_all()
     {
+        return $this->db->get($this->table)->result();
+    }
+
+    /**
+     * Ambil produk dengan filter kategori dan pencarian nama.
+     */
+    public function get_filtered($kategori = null, $keyword = null)
+    {
+        if ($kategori) {
+            $this->db->where('kategori', $kategori);
+        }
+        if ($keyword) {
+            $this->db->like('nama_produk', $keyword);
+        }
         return $this->db->get($this->table)->result();
     }
 

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -11,47 +11,68 @@
 <div class="row">
     <div class="col-md-6">
         <h4>Daftar Produk</h4>
-        <div class="list-group">
-        <?php foreach ($products as $p): ?>
-            <div class="list-group-item d-flex justify-content-between align-items-center">
-                <div>
-                    <strong><?php echo htmlspecialchars($p->nama_produk); ?></strong><br>
-                    <small>Rp <?php echo number_format($p->harga_jual, 0, ',', '.'); ?></small>
-                </div>
-                <a href="<?php echo site_url('pos/add/'.$p->id); ?>" class="btn btn-sm btn-success">Tambah</a>
-            </div>
-        <?php endforeach; ?>
-        </div>
+        <form class="form-inline mb-2" onsubmit="return false;">
+            <select name="kategori" id="category-filter" class="form-control mr-2">
+                <option value="">Semua Kategori</option>
+                <?php foreach ($categories as $c): ?>
+                    <option value="<?php echo $c->kategori; ?>" <?php echo ($selected_category == $c->kategori) ? 'selected' : ''; ?>><?php echo htmlspecialchars($c->kategori); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <input type="text" name="q" id="product-search" value="<?php echo htmlspecialchars($search_query); ?>" class="form-control mr-2" placeholder="Cari produk">
+        </form>
+        <table id="products-table" class="table table-sm table-bordered">
+            <thead>
+                <tr>
+                    <th>Produk</th>
+                    <th>Harga</th>
+                    <th>Kategori</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($products as $p): ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($p->nama_produk); ?></td>
+                    <td>Rp <?php echo number_format($p->harga_jual, 0, ',', '.'); ?></td>
+                    <td><?php echo htmlspecialchars($p->kategori); ?></td>
+                    <td><a href="<?php echo site_url('pos/add/'.$p->id); ?>" class="btn btn-sm btn-success">Tambah</a></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
     </div>
     <div class="col-md-6">
         <h4>Keranjang</h4>
         <?php if (!empty($cart)): ?>
-            <table class="table table-bordered">
-                <thead>
-                    <tr>
-                        <th>Produk</th>
-                        <th>Qty</th>
-                        <th>Subtotal</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php foreach ($cart as $item): ?>
-                    <tr>
-                        <td><?php echo htmlspecialchars($item['nama_produk']); ?></td>
-                        <td><?php echo $item['qty']; ?></td>
-                        <td>Rp <?php echo number_format($item['harga_jual'] * $item['qty'], 0, ',', '.'); ?></td>
-                        <td><a href="<?php echo site_url('pos/remove/'.$item['id']); ?>" class="btn btn-sm btn-danger">Hapus</a></td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <th colspan="2">Total</th>
-                        <th colspan="2">Rp <?php echo number_format($total, 0, ',', '.'); ?></th>
-                    </tr>
-                </tfoot>
-            </table>
+            <form method="post" action="<?php echo site_url('pos/update_cart'); ?>">
+                <table class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Produk</th>
+                            <th>Qty</th>
+                            <th>Subtotal</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($cart as $item): ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($item['nama_produk']); ?></td>
+                            <td><input type="number" name="qty[<?php echo $item['id']; ?>]" value="<?php echo $item['qty']; ?>" min="1" class="form-control form-control-sm"></td>
+                            <td>Rp <?php echo number_format($item['harga_jual'] * $item['qty'], 0, ',', '.'); ?></td>
+                            <td><a href="<?php echo site_url('pos/remove/'.$item['id']); ?>" class="btn btn-sm btn-danger">Hapus</a></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="2"><button type="submit" class="btn btn-secondary btn-sm">Update Qty</button></td>
+                            <th>Total</th>
+                            <th>Rp <?php echo number_format($total, 0, ',', '.'); ?></th>
+                        </tr>
+                    </tfoot>
+                </table>
+            </form>
             <form method="post" action="<?php echo site_url('pos/checkout'); ?>">
                 <input type="hidden" name="device_date" id="device_date">
                 <button type="submit" class="btn btn-primary">Checkout</button>
@@ -67,6 +88,38 @@ var deviceInput = document.getElementById('device_date');
 if (deviceInput) {
     var now = new Date();
     deviceInput.value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+}
+
+var searchInput = document.getElementById('product-search');
+var categorySelect = document.getElementById('category-filter');
+var productsBody = document.querySelector('#products-table tbody');
+var searchUrl = '<?php echo site_url('pos/search'); ?>';
+var addUrl = '<?php echo site_url('pos/add/'); ?>';
+
+function renderProducts(items) {
+    productsBody.innerHTML = '';
+    items.forEach(function(p) {
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td>' + p.nama_produk + '</td>' +
+                       '<td>Rp ' + Number(p.harga_jual).toLocaleString('id-ID') + '</td>' +
+                       '<td>' + p.kategori + '</td>' +
+                       '<td><a href="' + addUrl + p.id + '" class="btn btn-sm btn-success">Tambah</a></td>';
+        productsBody.appendChild(tr);
+    });
+}
+
+function updateProducts() {
+    var params = new URLSearchParams();
+    if (categorySelect.value) params.append('kategori', categorySelect.value);
+    if (searchInput.value) params.append('q', searchInput.value);
+    fetch(searchUrl + '?' + params.toString())
+        .then(function(r){ return r.json(); })
+        .then(renderProducts);
+}
+
+if (searchInput && categorySelect) {
+    searchInput.addEventListener('input', updateProducts);
+    categorySelect.addEventListener('change', updateProducts);
 }
 </script>
 <?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
## Summary
- add Product_model helper functions for categories and filtered queries
- enable category and keyword filtering in Pos controller
- improve POS product list with category filter, search box, and table layout
- introduce AJAX endpoint and live search script for instant product filtering
- allow bulk quantity edits in the cart with new update_cart endpoint and input form

## Testing
- `php -l application/models/Product_model.php`
- `php -l application/controllers/Pos.php`
- `php -l application/views/pos/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad693c223483208408e1963ebbd83e